### PR TITLE
Refactor TERMINUS_DOES_MULTIDEV_EXIST logic

### DIFF
--- a/.circleci/deploy-to-pantheon.sh
+++ b/.circleci/deploy-to-pantheon.sh
@@ -3,7 +3,13 @@
 set -ex
 
 TERMINUS_DOES_MULTIDEV_EXIST()
-{
+{    
+    # Return 1 if on master since dev always exists
+    if [[ ${CIRCLE_BRANCH} == "master" ]]
+    then
+        return 1;
+    fi
+
     # Stash list of Pantheon multidev environments
     PANTHEON_MULTIDEV_LIST="$(terminus multidev:list -n ${TERMINUS_SITE} --format=list --field=Name)"
 
@@ -23,7 +29,7 @@ then
     exit 0;
 fi
 
-if -n ${CIRCLE_PULL_REQUEST+x} && ! TERMINUS_DOES_MULTIDEV_EXIST ${TERMINUS_ENV}
+if ! TERMINUS_DOES_MULTIDEV_EXIST ${TERMINUS_ENV}
 then
     terminus env:wake -n "$TERMINUS_SITE.dev"
     terminus build:env:create -n "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --clone-content --yes --notify="$NOTIFY"


### PR DESCRIPTION
`-if -n ${CIRCLE_PULL_REQUEST+x}` was returning `./.circleci/deploy-to-pantheon.sh: line 26: conditional binary operator expected` errors in Circle CI.

Having `TERMINUS_DOES_MULTIDEV_EXIST` return `1` when on the `master` branch eliminates the need for that part of the conditional.