### PR TITLE
Fixes so that derivative repos match this repo and pass CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ defaults: &defaults
 version: 2
 jobs:
     # @todo: common initialization, maybe
-    install_dev_dependencies:
+    build:
         <<: *defaults
         steps:
             - checkout
@@ -146,18 +146,18 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build_and_test:
     jobs:
       # Install dev dependencies
-      - install_dev_dependencies
+      - build
       # Build and deploy
       - build_and_deploy
       # Code sniff and unit text first
       - code_sniff_unit_test:
             requires:
-                - install_dev_dependencies
+                - build
       # Run Behat tests after deploy so they can be done on Pantheon
       - behat_test:
             requires:
-                - install_dev_dependencies
+                - build
                 - build_and_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  build:
     jobs:
       # Install dev dependencies
       - install_dev_dependencies

--- a/.circleci/deploy-to-pantheon.sh
+++ b/.circleci/deploy-to-pantheon.sh
@@ -23,7 +23,9 @@ TERMINUS_DOES_MULTIDEV_EXIST()
     return 1;
 }
 
-if [[ (${CIRCLE_BRANCH} != "master" && -z ${CIRCLE_PULL_REQUEST+x}) || (${CIRCLE_BRANCH} == "master" && -n ${CIRCLE_PULL_REQUEST+x}) ]];
+# I don't know if on non-pull requests CIRCLE_PULL_REQUEST is empty or complete
+# absent -z will return true in either cases.
+if [[ ${CIRCLE_BRANCH} != "master" && -z ${CIRCLE_PULL_REQUEST} ]];
 then
     echo -e "CircleCI will only deploy to Pantheon if on the master branch or creating a pull requests.\n"
     exit 0;

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ web/*
 !web/wp-cli.yml
 !web/wp-config.php
 !web/wp-content/
-web/wp-content
+web/wp-content/*
 !web/wp-content/mu-plugins/
 web/wp-content/mu-plugins/*
 !web/wp-content/mu-plugins/custom


### PR DESCRIPTION
@ataylorme @greg-1-anderson, I've tried to spin up derivative repos from `example-wordpress-composer` and run into a few problems.  One is that the CircleCI builds on the newly created repos fail with 

```
Configuration errors: 1 error occurred:

* job 'build' is not found
```

See 

https://circleci.com/gh/stevector/stevector-composer/1
https://circleci.com/gh/stevector/wordpress-composer-php56/1

More concerning for me is that our CI builds started from the Terminus Build Tools Plugin have also failed, but I didn't notice. 

https://circleci.com/gh/pantheon-ci-bot/build-tools-600/1
https://circleci.com/gh/pantheon-ci-bot/build-tools-595/1

Maybe I didn't notice because we still get a green badge on https://github.com/pantheon-systems/terminus-build-tools-plugin  (Presumably because the Drupal 8 test takes the longest to run and the badge only reports on the very latest build number?)

Anyway, it looks like we need to go back 30 days to find a passing build on WordPress: https://circleci.com/gh/pantheon-systems/terminus-build-tools-plugin/tree/master


