### PR TITLE
Move quicksilver-pushback to require and not require-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Even within the `/web` directory you may notice that other directories and files
 
 #### `composer.json`
 
-If you are just browsing this repository on GitHub, you may not see some of the directories mentioned above like `wp-admin`. That is because WordPress core and its plugins are installed via Composer and ignored in the `.gitignore` file. Specific plugins are added to the project via `composer.json` and `composer.lock` keeps track of the exact version of each plugin (or other dependency). Generic Composer dependencies (not WordPress plugins or themes) are downloaded to the `/vendor` folder.
-@todo add sentence about `require` vs. `require-dev`
+If you are just browsing this repository on GitHub, you may not see some of the directories mentioned above like `wp-admin`. That is because WordPress core and its plugins are installed via Composer and ignored in the `.gitignore` file. Specific plugins are added to the project via `composer.json` and `composer.lock` keeps track of the exact version of each plugin (or other dependency). Generic Composer dependencies (not WordPress plugins or themes) are downloaded to the `/vendor` folder. Use the `require` section for any dependencies you wish to push to Pantheon, even those that might only be used on non-Live environments. Dependencies added in `require-dev` such as `php_codesniffer` or `phpunit` will not be pushed to Pantheon by the CI scripts.
 
 ## Behat tests
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Even within the `/web` directory you may notice that other directories and files
 #### `composer.json`
 
 If you are just browsing this repository on GitHub, you may not see some of the directories mentioned above like `wp-admin`. That is because WordPress core and its plugins are installed via Composer and ignored in the `.gitignore` file. Specific plugins are added to the project via `composer.json` and `composer.lock` keeps track of the exact version of each plugin (or other dependency). Generic Composer dependencies (not WordPress plugins or themes) are downloaded to the `/vendor` folder.
+@todo add sentence about `require` vs. `require-dev`
 
 ## Behat tests
 

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
   ],
   "require": {
     "composer/installers": "^1.3.0",
-    "vlucas/phpdotenv": "^2.4.0",
-    "wpackagist-plugin/wp-native-php-sessions": "^0.6.0",
-    "wpackagist-plugin/pantheon-advanced-page-cache": "^0.1.4",
-    "wpackagist-theme/twentyseventeen": "^1.1",
+    "pantheon-systems/quicksilver-pushback": "^1.0",
     "pantheon-systems/wordpress-composer": "^4.8.2",
     "roots/wp-password-bcrypt": "^1.0.0",
-    "rvtraveller/qs-composer-installer": "^1.1"
+    "rvtraveller/qs-composer-installer": "^1.1",
+    "vlucas/phpdotenv": "^2.4.0",
+    "wpackagist-plugin/pantheon-advanced-page-cache": "^0.1.4",
+    "wpackagist-plugin/wp-native-php-sessions": "^0.6.0",
+    "wpackagist-theme/twentyseventeen": "^1.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "wpackagist-plugin/wp-native-php-sessions": "^0.6.0",
     "wpackagist-plugin/pantheon-advanced-page-cache": "^0.1.4",
     "wpackagist-theme/twentyseventeen": "^1.1",
+    "pantheon-systems/quicksilver-pushback": "~1",
     "pantheon-systems/wordpress-composer": "^4.8.1",
     "roots/wp-password-bcrypt": "^1.0.0",
     "rvtraveller/qs-composer-installer": "^1.1"
@@ -33,8 +34,7 @@
     "squizlabs/php_codesniffer": "^2.9.0",
     "wp-coding-standards/wpcs": "dev-master",
     "phpunit/phpunit": "^6.1",
-    "brain/monkey": "^1.4",
-    "pantheon-systems/quicksilver-pushback": "~1"
+    "brain/monkey": "^1.4"
   },
   "config": {
     "vendor-dir": "vendor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "add683d486509ed81711e5aa909f3f27",
+    "content-hash": "ae2f8302caec7a59567a719e8a866511",
     "packages": [
         {
             "name": "composer/installers",
@@ -170,6 +170,31 @@
                 "wordpress"
             ],
             "time": "2015-06-11T15:15:30+00:00"
+        },
+        {
+            "name": "pantheon-systems/quicksilver-pushback",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pantheon-systems/quicksilver-pushback.git",
+                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pantheon-systems/quicksilver-pushback/zipball/32c65effd6802bdf829f1c68fb75ade2bd5894a0",
+                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "quicksilver-script",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Push commits made via the Pantheon dashboard back to original GitHub repository.",
+            "time": "2017-07-21T17:10:28+00:00"
         },
         {
             "name": "pantheon-systems/wordpress-composer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d05cd60d1fcedf13db558b202c48fbff",
+    "content-hash": "a51a8a47516448c6a953702e6c49c757",
     "packages": [
         {
             "name": "composer/installers",
@@ -170,6 +170,31 @@
                 "wordpress"
             ],
             "time": "2015-06-11T15:15:30+00:00"
+        },
+        {
+            "name": "pantheon-systems/quicksilver-pushback",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pantheon-systems/quicksilver-pushback.git",
+                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pantheon-systems/quicksilver-pushback/zipball/32c65effd6802bdf829f1c68fb75ade2bd5894a0",
+                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "quicksilver-script",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Push commits made via the Pantheon dashboard back to original GitHub repository.",
+            "time": "2017-07-21T17:10:28+00:00"
         },
         {
             "name": "pantheon-systems/wordpress-composer",
@@ -361,7 +386,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/pantheon-advanced-page-cache.0.1.5.zip",
-                "reference": null,
+                "reference": "tags/0.1.5",
                 "shasum": null
             },
             "require": {
@@ -381,7 +406,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/wp-native-php-sessions.0.6.2.zip",
-                "reference": null,
+                "reference": "tags/0.6.2",
                 "shasum": null
             },
             "require": {
@@ -401,7 +426,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/theme/twentyseventeen.1.3.zip",
-                "reference": null,
+                "reference": "1.3",
                 "shasum": null
             },
             "require": {
@@ -1627,31 +1652,6 @@
                 "service proxies"
             ],
             "time": "2016-11-04T15:53:15+00:00"
-        },
-        {
-            "name": "pantheon-systems/quicksilver-pushback",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pantheon-systems/quicksilver-pushback.git",
-                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/quicksilver-pushback/zipball/32c65effd6802bdf829f1c68fb75ade2bd5894a0",
-                "reference": "32c65effd6802bdf829f1c68fb75ade2bd5894a0",
-                "shasum": ""
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "quicksilver-script",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Push commits made via the Pantheon dashboard back to original GitHub repository.",
-            "time": "2017-07-21T17:10:28+00:00"
         },
         {
             "name": "paulgibbs/behat-wordpress-extension",

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -15,5 +15,5 @@ workflows:
   sync_code:
     after:
       - type: webphp
-        description: Push changes back to GitHub if needed
+        description: 'Push changes back to GitHub if needed'
         script: private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php

--- a/quicksilver-pushback-test.txt
+++ b/quicksilver-pushback-test.txt
@@ -1,1 +1,0 @@
-Quicksilver platform hooks for the win

--- a/quicksilver-pushback-test.txt
+++ b/quicksilver-pushback-test.txt
@@ -1,0 +1,1 @@
+Quicksilver platform hooks for the win


### PR DESCRIPTION
Replacing https://github.com/pantheon-systems/example-wordpress-composer/pull/38 with no merge conflicts against master and fewer changes in composer.lock