### PR TITLE
Remove --stability=dev from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export CIRCLE_TOKEN=[REDACTED]
 Once you have all of the prerequisites in place, you can create your copy of this repo with one command:
 
 ```
-terminus build:project:create pantheon-systems/example-wordpress-composer my-new-site --team="Agency Org Name" --stability=dev
+terminus build:project:create pantheon-systems/example-wordpress-composer my-new-site --team="Agency Org Name"
 ```
 
 The parameters shown here are:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "pantheon-systems/example-wordpress-composer",
   "description": "",
-  "version": "0.1.0",
   "type": "project",
   "keywords": [],
   "minimum-stability": "alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae2f8302caec7a59567a719e8a866511",
+    "content-hash": "bba12d576b493a9fa2645306875bc844",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
1.0.0 has been tagged and we should be able to do `composer create-project` or `terminus build:project:create` without specifying a dev version.