### PR TITLE
added correct path to wpcs and WPcs standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,8 @@
       "WordPressProject\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "code-sniff": [
-      "./vendor/bin/phpcs --config-set installed_paths ./vendor/wp-coding-standards/wpcs",
-      "./vendor/bin/phpcs ./web/wp-content"
+      "./vendor/bin/phpcs --config-set installed_paths ~/example-wordpress-composer/vendor/wp-coding-standards/wpcs",
+      "./vendor/bin/phpcs --standard=WordPress ./web/wp-content"
     ],
     "unit-test": [
       "./vendor/bin/phpunit tests/unit/*"


### PR DESCRIPTION
Running this repo out of the box and adding some custom coded WP template/plugin, the circleci build is not completing successfully because of codesniffer error not referencing the WP coding standards in the correct path and not defined as the default sniff standard