### PR TITLE
Edits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# copy this to .env
+# to get your enviornment started
+DB_NAME=
+DB_USER=
+DB_HOST=
+DB_PASSWORD=
+WP_DEBUG=
+WP_DEBUG_DISPLAY=
+WP_DEBUG_LOG=
+IS_LOCAL=

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ web/private/*
 web/private/scripts/quicksilver
 !web/private/config/
 !.circleci
+.env
 
 # Add directories containing build assets below.
 # Keep all additions above the "cut" line.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Even within the `/web` directory you may notice that other directories and files
 
 If you are just browsing this repository on GitHub, you may not see some of the directories mentioned above like `wp-admin`. That is because WordPress core and its plugins are installed via Composer and ignored in the `.gitignore` file. Specific plugins are added to the project via `composer.json` and `composer.lock` keeps track of the exact version of each plugin (or other dependency). Generic Composer dependencies (not WordPress plugins or themes) are downloaded to the `/vendor` folder. Use the `require` section for any dependencies you wish to push to Pantheon, even those that might only be used on non-Live environments. Dependencies added in `require-dev` such as `php_codesniffer` or `phpunit` will not be pushed to Pantheon by the CI scripts.
 
+#### `.env`
+
+For local development, copy the `.env.example` file to `.env` and set the variables equal to your local development configuration.
+```
+DB_NAME=[String - Database Name]
+DB_USER=[String - Database User]
+DB_HOST=[String - Database Host Location]
+DB_PASSWORD=[String - Database User Password]
+WP_DEBUG=[Boolean - Initiate WP DEBUG]
+WP_DEBUG_DISPLAY=[Boolean - Display Wordpress and PHP errors on page]
+WP_DEBUG_LOG=[Boolean - Log to a file at web/wp-content/debug.log]
+IS_LOCAL=[Boolean - Whether or not this is a local install]
+```
+
 ## Behat tests
 
 So that CircleCI will have some test to run, this repository includes a configuration of [WordHat](https://wordhat.info/), A WordPress Behat extension. You can add your own `.feature` files within `/tests/behat/features`. [A fuller guide on WordPress testing with Behat is forthcoming.](https://github.com/pantheon-systems/documentation/issues/2469)

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -35,8 +35,9 @@ define( 'DISALLOW_FILE_MODS', true );
 
 /**
  * Force SSL
+ * turning off - jd
  */
-define( 'FORCE_SSL_ADMIN', true );
+define( 'FORCE_SSL_ADMIN', false );
 
 /**
  * Limit post revisions
@@ -58,9 +59,12 @@ if ( ! isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 	if ( isset( $_SERVER['HTTP_USER_AGENT_HTTPS'] ) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON' ) {
 		$scheme = 'https';
 	}
-	$site_url = getenv( 'WP_HOME' ) !== false ? getenv( 'WP_HOME' ) : $scheme . '://' . $_SERVER['HTTP_HOST'] . '/';
-	define( 'WP_HOME', $site_url );
-	define( 'WP_SITEURL', $site_url . 'wp/' );
+
+	if ( isset($_SERVER['HTTP_HOST']) ) {
+		$site_url = getenv( 'WP_HOME' ) !== false ? getenv( 'WP_HOME' ) : $scheme . '://' . $_SERVER['HTTP_HOST'] . '/';
+		define( 'WP_HOME', $site_url );
+		define( 'WP_SITEURL', $site_url . 'wp/' );
+	}
 
 	/**
 	 * Set Database Details
@@ -74,6 +78,8 @@ if ( ! isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 	 * Set debug modes
 	 */
 	define( 'WP_DEBUG', getenv( 'WP_DEBUG' ) === 'true' ? true : false );
+	define( 'WP_DEBUG_LOG', getenv( 'WP_DEBUG_LOG' ) === 'true' ? true : false );
+	define( 'WP_DEBUG_DISPLAY', getenv( 'WP_DEBUG_DISPLAY' ) === 'true' ? true : false );
 	define( 'IS_LOCAL', getenv( 'IS_LOCAL' ) !== false ? true : false );
 
 	/**#@+
@@ -174,7 +180,9 @@ endif;
 * Define wp-content directory outside of WordPress core directory
 */
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content' );
-define( 'WP_CONTENT_URL', WP_HOME . '/wp-content' );
+if ( defined('WP_HOME') ) {
+	define( 'WP_CONTENT_URL', WP_HOME . '/wp-content' );
+}
 
 /**
  * WordPress Database Table prefix.


### PR DESCRIPTION
Hey, I noticed that this repo uses Dotenv but lacked a .env.example. I also noticed that there wasn't anything in the README about setting up the .env for local development. I also added some WP_DEBUG definitions for the .env in the wp-config.php. This way I could use the .env to set my ideal WP_DEBUG rules (display off, but debug.log on). I hope this is useful and helpful. I'll keep trying to commit as I find time.