### PR TITLE
Remove PHP version declaration

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,6 +1,5 @@
 api_version: 1
 web_docroot: true
-php_version: 7.2
 workflows:
   sync_code:
     after:


### PR DESCRIPTION
The PHP version declaration was originally added for PHP `7.x` support when Pantheon sites, via `pantheon.upstream.yml`, used PHP `5.x` by default. [`pantheon.upstream.yml` is on PHP `7.x`](https://github.com/pantheon-systems/WordPress/blob/default/pantheon.upstream.yml#L6) so specifying a PHP version in `pantheon.yml` is no longer required.