### PR TITLE
Allow for more recent versions of WPNPS and PAPC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "rvtraveller/qs-composer-installer": "^1.1",
     "vlucas/phpdotenv": "^3.1.0",
     "wpackagist-plugin/lh-hsts": "^1.24",
-    "wpackagist-plugin/pantheon-advanced-page-cache": "^0.3.0",
-    "wpackagist-plugin/wp-native-php-sessions": "^0.6.9",
+    "wpackagist-plugin/pantheon-advanced-page-cache": ">=0.3.0",
+    "wpackagist-plugin/wp-native-php-sessions": ">=0.6.9",
     "wpackagist-theme/twentynineteen": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
`^` constrains to patch releases when there isn't yet a 1.0 released.