### PR TITLE
Add prepare for Pantheon before deploying

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -11,6 +11,9 @@ set -eo pipefail
 # Authenticate with Terminus
 terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
 
+# Prepare for Pantheon
+composer run prepare-for-pantheon
+
 if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
 then
     # Create a new multidev environment (or push to an existing one)


### PR DESCRIPTION
This ensures a proper `.gitignore` is deployed. We could persist `.gitignore` from the PHP build job. However, running prepare for Pantheon just before deployment ensures the proper cleanup runs even as more build jobs, such as Node, are added, which is useful if `npm` downloads `.git` directories as well.