### PR TITLE
Use "-r" instead of "-a" in rsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       # Rsync the build artifact pieces web directory
       - run:
           name: sync build artifact
-          command: rsync -az /tmp/web /tmp/vendor .
+          command: rsync -rz /tmp/web /tmp/vendor .
 
       # Deploy to Pantheon
       - run:

--- a/scripts/composer/cleanup-composer
+++ b/scripts/composer/cleanup-composer
@@ -4,7 +4,7 @@
 set -ex
 
 if [ -d "web/wp/wp-content/mu-plugins/" ]; then
-  rsync -a web/wp/wp-content/mu-plugins/* web/wp-content/mu-plugins/
+  rsync -r web/wp/wp-content/mu-plugins/* web/wp-content/mu-plugins/
 fi
 
 if [ -f "web/wp/wp-config.php" ]; then


### PR DESCRIPTION
This fixes #184 by replacing `-a` flag for `-r` flag in the `rsync` commands (special thanks to @ataylorme).