### PR TITLE
[PRT-227] Update to PHP 7.4 and MariaDB 10.4

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,6 +1,11 @@
 api_version: 1
 web_docroot: true
 php_version: 7.4
+
+# See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
+database:
+  version: 10.4
+
 workflows:
   sync_code:
     after:


### PR DESCRIPTION
For details, see https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb

See also pantheon-systems/documentation#6928, which modifies that section.